### PR TITLE
Nuevas extensiones: cuenta_atras, mostrar_como_lista y descuento

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ChangeListManager">
-    <list default="true" id="fa75db07-a88d-4a86-9297-3e0dbb0319e5" name="Default" comment="Creada lista de ofertas en otras ciudades">
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/app/config/services.yml" />
+    <list default="true" id="fa75db07-a88d-4a86-9297-3e0dbb0319e5" name="Default" comment="">
+      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/app/config/config.yml" afterPath="$PROJECT_DIR$/app/config/config.yml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/app/config/services.yml" afterPath="$PROJECT_DIR$/app/config/services.yml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig" afterPath="$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig" />
     </list>
     <ignored path="cupon-2.4.iws" />
     <ignored path=".idea/workspace.xml" />
@@ -25,31 +26,11 @@
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file leaf-file-name="routing.yml" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/app/config/routing.yml">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="330">
-              <caret line="22" column="15" selection-start-line="22" selection-start-column="15" selection-end-line="22" selection-end-column="15" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
       <file leaf-file-name="config.yml" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/app/config/config.yml">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="45">
               <caret line="3" column="31" selection-start-line="3" selection-start-column="31" selection-end-line="3" selection-end-column="31" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="services.yml" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/app/config/services.yml">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="135">
-              <caret line="9" column="38" selection-start-line="9" selection-start-column="38" selection-end-line="9" selection-end-column="38" />
               <folding />
             </state>
           </provider>
@@ -67,17 +48,27 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="OfertaRepository.php" pinned="false" current-in-tab="true">
+      <file leaf-file-name="OfertaRepository.php" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Entity/OfertaRepository.php">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="550">
-              <caret line="51" column="38" selection-start-line="51" selection-start-column="38" selection-end-line="51" selection-end-column="38" />
+            <state relative-caret-position="295">
+              <caret line="34" column="0" selection-start-line="34" selection-start-column="0" selection-end-line="34" selection-end-column="0" />
               <folding>
                 <element signature="e#123#157#0#PHP" expanded="true" />
-                <marker date="1471213738000" expanded="true" signature="401:637" ph="SELECT o, c,... OfertaBundle" />
-                <marker date="1471213738000" expanded="true" signature="973:1253" ph="SELECT o, c OfertaBundle" />
-                <marker date="1471213738000" expanded="true" signature="1633:1928" ph="SELECT o, c,... OfertaBundle" />
+                <marker date="1471269110000" expanded="true" signature="401:637" ph="SELECT o, c,... OfertaBundle" />
+                <marker date="1471269110000" expanded="true" signature="973:1253" ph="SELECT o, c OfertaBundle" />
+                <marker date="1471269110000" expanded="true" signature="1633:1928" ph="SELECT o, c,... OfertaBundle" />
               </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name=".gitignore" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/.gitignore">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="225">
+              <caret line="17" column="0" selection-start-line="17" selection-start-column="0" selection-end-line="17" selection-end-column="0" />
+              <folding />
             </state>
           </provider>
         </entry>
@@ -92,11 +83,54 @@
           </provider>
         </entry>
       </file>
+      <file leaf-file-name="oferta.html.twig" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="225">
+              <caret line="15" column="24" selection-start-line="15" selection-start-column="24" selection-end-line="15" selection-end-column="24" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="CuponExtension.php" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="66">
+              <caret line="50" column="21" selection-start-line="50" selection-start-column="21" selection-end-line="50" selection-end-column="21" />
+              <folding>
+                <element signature="e#6#83#0#PHP" expanded="true" />
+                <marker date="1471269110000" expanded="true" signature="2349:2380" ph="{...}" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="services.yml" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/app/config/services.yml">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="195">
+              <caret line="13" column="36" selection-start-line="13" selection-start-column="36" selection-end-line="13" selection-end-column="36" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
       <file leaf-file-name="frontend.html.twig" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/app/Resources/views/frontend.html.twig">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="630">
+            <state relative-caret-position="483">
               <caret line="42" column="0" selection-start-line="42" selection-start-column="0" selection-end-line="42" selection-end-column="0" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="detalle.html.twig" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/detalle.html.twig">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="165">
+              <caret line="11" column="17" selection-start-line="11" selection-start-column="17" selection-end-line="11" selection-end-column="17" />
               <folding />
             </state>
           </provider>
@@ -153,15 +187,16 @@
         <option value="$PROJECT_DIR$/src/Cupon/CiudadBundle/Controller/DefaultController.php" />
         <option value="$PROJECT_DIR$/src/Cupon/CiudadBundle/Resources/config/routing.yml" />
         <option value="$PROJECT_DIR$/app/config/routing.yml" />
-        <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig" />
         <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/portada.html.twig" />
         <option value="$PROJECT_DIR$/app/Resources/views/frontend.html.twig" />
         <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/detalle.html.twig" />
         <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Controller/DefaultController.php" />
-        <option value="$PROJECT_DIR$/.gitignore" />
-        <option value="$PROJECT_DIR$/app/config/services.yml" />
         <option value="$PROJECT_DIR$/app/config/config.yml" />
+        <option value="$PROJECT_DIR$/.gitignore" />
         <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Entity/OfertaRepository.php" />
+        <option value="$PROJECT_DIR$/app/config/services.yml" />
+        <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig" />
+        <option value="$PROJECT_DIR$/src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php" />
       </list>
     </option>
   </component>
@@ -483,6 +518,36 @@
               <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
             </PATH_ELEMENT>
             <PATH_ELEMENT>
+              <option name="myItemId" value="Twig" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Extension" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="cupon-2.4" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="cupon-2.4" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="src" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Cupon" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="OfertaBundle" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
               <option name="myItemId" value="Resources" />
               <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
             </PATH_ELEMENT>
@@ -526,6 +591,44 @@
             </PATH_ELEMENT>
             <PATH_ELEMENT>
               <option name="myItemId" value="Default" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="cupon-2.4" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="cupon-2.4" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="src" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Cupon" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="OfertaBundle" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Resources" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="views" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Default" />
+              <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="includes" />
               <option name="myItemType" value="com.jetbrains.php.projectView.PhpTreeStructureProvider$1" />
             </PATH_ELEMENT>
           </PATH>
@@ -934,7 +1037,7 @@
       <workItem from="1470995351325" duration="16514000" />
       <workItem from="1471112030820" duration="51000" />
       <workItem from="1471112171827" duration="6312000" />
-      <workItem from="1471211258875" duration="1983000" />
+      <workItem from="1471211258875" duration="8667000" />
     </task>
     <task id="LOCAL-00001" summary="Empty project testing symfony">
       <created>1470722596487</created>
@@ -1020,11 +1123,32 @@
       <option name="project" value="LOCAL" />
       <updated>1471210489231</updated>
     </task>
-    <option name="localTasksCounter" value="13" />
+    <task id="LOCAL-00013" summary="Incluyendo las extensiones de Twig de Text y Debug">
+      <created>1471213785341</created>
+      <option name="number" value="00013" />
+      <option name="presentableId" value="LOCAL-00013" />
+      <option name="project" value="LOCAL" />
+      <updated>1471213785341</updated>
+    </task>
+    <task id="LOCAL-00014" summary="Solucionando error en la consulta de ofertas relacionadas. Salían ofertas de la ciudad que estaba cargada.">
+      <created>1471213997770</created>
+      <option name="number" value="00014" />
+      <option name="presentableId" value="LOCAL-00014" />
+      <option name="project" value="LOCAL" />
+      <updated>1471213997770</updated>
+    </task>
+    <task id="LOCAL-00015" summary=" workspace">
+      <created>1471215264188</created>
+      <option name="number" value="00015" />
+      <option name="presentableId" value="LOCAL-00015" />
+      <option name="project" value="LOCAL" />
+      <updated>1471215264188</updated>
+    </task>
+    <option name="localTasksCounter" value="16" />
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="59713000" />
+    <option name="totallyTimeSpent" value="66397000" />
   </component>
   <component name="TodoView" selected-index="2">
     <todo-panel id="selected-file">
@@ -1101,7 +1225,10 @@
     <MESSAGE value="Incluido desplegable que permite cambiar de ciudad en la portada, para cargar la oferta del día relacionada con dicha ciudad" />
     <MESSAGE value="Creada la página que visualiza una oferta de una ciudad" />
     <MESSAGE value="Creada lista de ofertas en otras ciudades" />
-    <option name="LAST_COMMIT_MESSAGE" value="Creada lista de ofertas en otras ciudades" />
+    <MESSAGE value="Incluyendo las extensiones de Twig de Text y Debug" />
+    <MESSAGE value="Solucionando error en la consulta de ofertas relacionadas. Salían ofertas de la ciudad que estaba cargada." />
+    <MESSAGE value=" workspace" />
+    <option name="LAST_COMMIT_MESSAGE" value=" workspace" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -1110,13 +1237,6 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/app/AppKernel.php">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="330">
-          <caret line="22" column="72" selection-start-line="22" selection-start-column="72" selection-end-line="22" selection-end-column="72" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/composer.json">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="330">
@@ -1350,35 +1470,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/app/Resources/views/base.html.twig">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="15">
-          <caret line="1" column="15" selection-start-line="1" selection-start-column="15" selection-end-line="1" selection-end-column="15" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="30">
-          <caret line="5" column="27" selection-start-line="5" selection-start-column="27" selection-end-line="5" selection-end-column="28" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/app/Resources/views/frontend.html.twig">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="630">
-          <caret line="42" column="0" selection-start-line="42" selection-start-column="0" selection-end-line="42" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/detalle.html.twig">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="165">
-          <caret line="11" column="17" selection-start-line="11" selection-start-column="17" selection-end-line="11" selection-end-column="17" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Controller/DefaultController.php">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="225">
@@ -1386,30 +1477,6 @@
           <folding>
             <element signature="e#49#106#0#PHP" expanded="true" />
           </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/portada.html.twig">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="135">
-          <caret line="9" column="0" selection-start-line="9" selection-start-column="0" selection-end-line="9" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/.gitignore">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="405">
-          <caret line="27" column="0" selection-start-line="27" selection-start-column="0" selection-end-line="27" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/app/config/services.yml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="135">
-          <caret line="9" column="38" selection-start-line="9" selection-start-column="38" selection-end-line="9" selection-end-column="38" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -1421,15 +1488,82 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/.gitignore">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="225">
+          <caret line="17" column="0" selection-start-line="17" selection-start-column="0" selection-end-line="17" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Entity/OfertaRepository.php">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="550">
-          <caret line="51" column="38" selection-start-line="51" selection-start-column="38" selection-end-line="51" selection-end-column="38" />
+        <state relative-caret-position="295">
+          <caret line="34" column="0" selection-start-line="34" selection-start-column="0" selection-end-line="34" selection-end-column="0" />
           <folding>
             <element signature="e#123#157#0#PHP" expanded="true" />
-            <marker date="1471213738000" expanded="true" signature="401:637" ph="SELECT o, c,... OfertaBundle" />
-            <marker date="1471213738000" expanded="true" signature="973:1253" ph="SELECT o, c OfertaBundle" />
-            <marker date="1471213738000" expanded="true" signature="1633:1928" ph="SELECT o, c,... OfertaBundle" />
+            <marker date="1471269110000" expanded="true" signature="401:637" ph="SELECT o, c,... OfertaBundle" />
+            <marker date="1471269110000" expanded="true" signature="973:1253" ph="SELECT o, c OfertaBundle" />
+            <marker date="1471269110000" expanded="true" signature="1633:1928" ph="SELECT o, c,... OfertaBundle" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/Resources/views/frontend.html.twig">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="483">
+          <caret line="42" column="0" selection-start-line="42" selection-start-column="0" selection-end-line="42" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/detalle.html.twig">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="165">
+          <caret line="11" column="17" selection-start-line="11" selection-start-column="17" selection-end-line="11" selection-end-column="17" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/Resources/views/base.html.twig">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="15">
+          <caret line="1" column="15" selection-start-line="1" selection-start-column="15" selection-end-line="1" selection-end-column="15" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/portada.html.twig">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="135">
+          <caret line="9" column="0" selection-start-line="9" selection-start-column="0" selection-end-line="9" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/app/config/services.yml">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="195">
+          <caret line="13" column="36" selection-start-line="13" selection-start-column="36" selection-end-line="13" selection-end-column="36" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="225">
+          <caret line="15" column="24" selection-start-line="15" selection-start-column="24" selection-end-line="15" selection-end-column="24" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="66">
+          <caret line="50" column="21" selection-start-line="50" selection-start-column="21" selection-end-line="50" selection-end-column="21" />
+          <folding>
+            <element signature="e#6#83#0#PHP" expanded="true" />
+            <marker date="1471269110000" expanded="true" signature="2349:2380" ph="{...}" />
           </folding>
         </state>
       </provider>

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -8,3 +8,7 @@ services:
         class: Twig_Extension_Debug
         tags:
             - { name: twig.extension }
+    twig.extension.cupon:
+        class: Cupon\OfertaBundle\Twig\Extension\CuponExtension
+        tags:
+            - { name: twig.extension }

--- a/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig
+++ b/src/Cupon/OfertaBundle/Resources/views/Default/includes/oferta.html.twig
@@ -2,20 +2,20 @@
 
 <section class="descripcion">
     <h1><a href="{{ path('oferta', {'ciudad': oferta.ciudad.slug, 'slug': oferta.slug}) }}"> {{ oferta.nombre }} </a></h1>
-    {{ oferta.descripcion }}
+    {{ oferta.descripcion | mostrar_como_lista }}
     <a class="boton" href="#">Comprar</a>
 </section>
 
 <section class="galeria">
     <img alt="Fotografía de la oferta" src="{{ asset('uploads/images/' ~ oferta.rutaFoto) }}">
     <p class="precio">{{ oferta.precio }} &euro;
-        <span>{{ oferta.descuento }}</span></p>
+        <span>{{ descuento(oferta.precio, oferta.descuento) }}</span></p>
     <p><strong>Condiciones:</strong> {{ oferta.condiciones }}</p>
 </section>
 
 <section class="estado">
-    <div class="tiempo">
-        <strong>Faltan</strong>: {{ oferta.fechaExpiracion | date() }}
+    <div id="tiempo">
+        <strong>Faltan</strong>: {{ oferta.fechaExpiracion | cuenta_atras }}
     </div>
 
     <div class="compras">
@@ -45,5 +45,5 @@
 
 <section class="tienda">
     <h2>Sobre la tienda</h2>
-    {{ oferta.tienda.descripcion }}
+    {{ oferta.tienda.descripcion | wordwrap(40) | nl2br }}
 </section>

--- a/src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php
+++ b/src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: SaMa
+ * Date: 15/8/16
+ * Time: 10:22
+ */
+# src/Cupon/OfertaBundle/Twig/Extension/CuponExtension.php
+
+namespace Cupon\OfertaBundle\Twig\Extension;
+
+class CuponExtension extends \Twig_Extension
+{
+
+    public function getFunctions()
+    {
+        return array('descuento' => new \Twig_Function_Method($this, 'descuento'));
+    }
+
+    public function getFilters()
+    {
+        return array('cuenta_atras' => new \Twig_Filter_Method($this, 'cuentaAtras', array('is_safe' => array('html'))),
+                     'mostrar_como_lista' => new \Twig_Filter_Method($this, 'mostrarComoLista', array('is_safe' => array('html'))));
+    }
+
+    public function descuento($precio, $descuento, $decimales = 0)
+    {
+        if (!is_numeric($precio) || !is_numeric($descuento)){
+            return '-';
+        }
+
+        if ($descuento == 0 || $descuento == null){
+            return '0%';
+        }
+
+        $precio_original = $precio + $descuento;
+        $porcentaje = ($descuento / $precio_original) * 100;
+
+        return '-'.number_format($porcentaje, $decimales).'%';
+    }
+
+    public function mostrarComoLista($value, $tipo='ul')
+    {
+        $html = "<".$tipo.">\n";
+        $html .= "  <li>".str_replace("\n", "</li>\n  <li>", $value)."</li>\n";
+        $html .= "</".$tipo.">\n";
+
+        return $html;
+    }
+
+    public function cuentaAtras($fecha)
+    {
+        $fecha = $fecha->format('Y,')
+            .($fecha->format('m')-1)
+            .$fecha->format(',d,H,i,s');
+        $html = <<<EOJ
+<script type="text/javascript">
+function muestraCuentaAtras(){
+var horas, minutos, segundos;
+var ahora = new Date();
+var fechaExpiracion = new Date($fecha);
+var falta = Math.floor( (fechaExpiracion.getTime() - ahora.getTime()) /
+1000 );
+if (falta < 0) {
+cuentaAtras = '-';
+}
+else {
+horas = Math.floor(falta/3600);
+falta = falta % 3600;
+minutos = Math.floor(falta/60);
+falta = falta % 60;
+segundos = Math.floor(falta);
+cuentaAtras = (horas < 10 ? '0' + horas : horas) + 'h '
++ (minutos < 10 ? '0' + minutos : minutos) + 'm '
++ (segundos < 10 ? '0' + segundos : segundos) + 's ';
+setTimeout('muestraCuentaAtras()', 1000);
+}
+document.getElementById('tiempo').innerHTML = '<strong>Faltan:</strong> ' +
+cuentaAtras;
+}
+muestraCuentaAtras();
+</script>
+EOJ;
+
+        return $html;
+    }
+
+    public function getName()
+    {
+        return 'cupon';
+    }
+}


### PR DESCRIPTION
Incluyendo las nuevas extensiones que permiten mostrar la cuenta atras de la oferta, el descuento en % y la descripcción de la oferta como ul's
